### PR TITLE
Added ability to hide the completed hyperfog from the outliner

### DIFF
--- a/common/megastructures/zz_orbital_hyperfog.txt
+++ b/common/megastructures/zz_orbital_hyperfog.txt
@@ -208,4 +208,11 @@ orbital_hyperfog_3 = {
 			country_event = { id = nano_dialog.1313 }			# Notification
 		}
 	}
+	outliner_trigger = { 
+		this = { 
+			NOT = {
+				has_global_flag = flag_hide_complete_hyperfog
+			}
+		}
+	}
 }

--- a/common/scripted_effects/hide_hyperfog.txt
+++ b/common/scripted_effects/hide_hyperfog.txt
@@ -1,4 +1,4 @@
-# effect (UN)HIDE_HYPERFOG = yes
+# effect = { (UN)HIDE_HYPERFOG = yes }
 
 HIDE_HYPERFOG ={
 	set_global_flag = flag_hide_complete_hyperfog

--- a/common/scripted_effects/hide_hyperfog.txt
+++ b/common/scripted_effects/hide_hyperfog.txt
@@ -1,0 +1,9 @@
+# effect (UN)HIDE_HYPERFOG = yes
+
+HIDE_HYPERFOG ={
+	set_global_flag = flag_hide_complete_hyperfog
+}
+
+UNHIDE_HYPERFOG ={
+	remove_global_flag = flag_hide_complete_hyperfog
+}


### PR DESCRIPTION
I found that having all the hyperfogs showing up in the outliner was a bit annoying, since I usually have over a dozen of them, in the L-cluster alone.
They show up by default.
The scripted effects can be used in other places as well, like an "edict" ( that acts as a setting ), or other settings menu ( Mod Menu mod? )

In the console:
To hide them: effect = { HIDE_HYPERFOG = yes }
To restore them: effect = { UNHIDE_HYPERFOG = yes }
